### PR TITLE
feat: Stefan improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm run dev          # Start dev server (custom Node server + Socket.IO + Next.js hot reload)
+npm run build        # Production build
+npm start            # Start production server
+npm test             # Run Vitest tests (once)
+npm run test:watch   # Run Vitest in watch mode
+npm run lint         # Run ESLint
+```
+
+Run a single test file:
+```bash
+npx vitest run src/engine/__tests__/engine.test.ts
+```
+
+Tests live under `src/**/__tests__/**/*.test.ts`.
+
+## Architecture
+
+This is a **server-authoritative multiplayer Catan** game. The server owns all game state; clients are thin views that send actions and render state.
+
+### Data flow
+
+```
+Client UI → Socket.IO event → socketHandlers.ts → gameManager.ts → engine/ → broadcast updated state
+```
+
+### Server (`src/server/`)
+
+- `index.ts` — Creates HTTP server, attaches Socket.IO, calls `setupSocketHandlers`. Entry point for both `dev` and `start` scripts (run via `tsx`).
+- `socketHandlers.ts` — All Socket.IO event handlers (lobby join/create, game actions, reconnect). Calls into `roomManager` and `gameManager`.
+- `roomManager.ts` — In-memory room/player registry. Manages room codes, player slots, ready states, and socket-to-player mapping.
+- `gameManager.ts` — Owns `GameState` instances. Calls engine functions to process actions; sanitizes state per-player before broadcasting (hides other players' dev cards, deck contents).
+
+### Engine (`src/engine/`)
+
+Pure TypeScript game logic with no I/O dependencies. Each module handles one concern:
+
+- `types.ts` — All types, enums, constants, and utility functions (`emptyResourceHand`, `hasResources`, etc.)
+- `board.ts` — Hex board generation (axial coordinates), vertex/edge topology, harbor placement
+- `state.ts` — `GameState` initialization and the main `applyAction(state, playerAction)` reducer
+- `resources.ts` — Dice-roll resource distribution
+- `building.ts` — Settlement/city/road placement validation and application
+- `trading.ts` — Player-to-player and maritime trade logic
+- `devCards.ts` — Development card play logic (Knight, Road Building, Year of Plenty, Monopoly)
+- `robber.ts` — Robber movement and resource stealing
+- `scoring.ts` — Longest road calculation, Largest Army, victory point totals
+
+The engine barrel (`index.ts`) re-exports everything. Import from `"../engine"` or `"@/engine"`.
+
+### Client (`src/app/`, `src/components/`, `src/hooks/`, `src/stores/`)
+
+- `src/stores/gameStore.ts` — Single Zustand store holding connection state, room info, `GameState`, chat, and UI ephemeral state (selected action, pending robber/knight flows).
+- `src/hooks/useSocket.ts` — Singleton Socket.IO client (module-level `globalSocket`). Initializes listeners once. Saves/restores session via `sessionStorage` for reconnect. Exports action-dispatching helpers used by UI components.
+- `src/hooks/useSoundManager.ts` — Web Audio API sound effects.
+- `src/components/board/` — SVG board rendering (`HexTile`, `Harbor`). Board is rendered in unit-space coordinates multiplied by a hex-size constant.
+- `src/components/ui/` — Game UI panels (Lobby, DiceDisplay, GameLog, DiscardDialog, Tooltip).
+- `src/app/page.tsx` — Root page; renders Lobby or the game board based on `gameState`.
+
+### Key design decisions
+
+- **No database** — all state is in-memory on the server; a restart clears all games.
+- **State sanitization** — `sanitizeStateForPlayer` in `gameManager.ts` strips hidden info (dev card deck order, other players' `newDevCards`) before sending to each client.
+- **Session reconnect** — `sessionStorage` stores `(roomCode, playerId)`; on reconnect the client emits `rejoin_room` and the server restores the socket mapping.
+- **Extended board** — 5–6 player games use the 31-hex extended board with different terrain/token distributions (all defined in `types.ts`).
+- **`@` alias** — `tsconfig.json` maps `@` → `src/`. Use `@/engine`, `@/stores/gameStore`, etc.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,31 +13,7 @@ import GameLog from "@/components/ui/GameLog";
 import Scoreboard from "@/components/ui/Scoreboard";
 import DiscardDialog from "@/components/ui/DiscardDialog";
 import DiceDisplay from "@/components/ui/DiceDisplay";
-import { GamePhase, TurnPhase, DevelopmentCardType } from "@/engine/types";
-
-const DEV_CARD_NAMES: Record<DevelopmentCardType, string> = {
-  [DevelopmentCardType.Knight]: "Knight",
-  [DevelopmentCardType.RoadBuilding]: "Road Building",
-  [DevelopmentCardType.YearOfPlenty]: "Year of Plenty",
-  [DevelopmentCardType.Monopoly]: "Monopoly",
-  [DevelopmentCardType.VictoryPoint]: "Victory Point",
-};
-
-const DEV_CARD_ICONS: Record<DevelopmentCardType, string> = {
-  [DevelopmentCardType.Knight]: "🗡️",
-  [DevelopmentCardType.RoadBuilding]: "🛤️",
-  [DevelopmentCardType.YearOfPlenty]: "🎁",
-  [DevelopmentCardType.Monopoly]: "💰",
-  [DevelopmentCardType.VictoryPoint]: "⭐",
-};
-
-const DEV_CARD_DESC: Record<DevelopmentCardType, string> = {
-  [DevelopmentCardType.Knight]: "Move the robber and steal a resource from an adjacent player.",
-  [DevelopmentCardType.RoadBuilding]: "Place 2 roads for free.",
-  [DevelopmentCardType.YearOfPlenty]: "Take any 2 resources from the bank.",
-  [DevelopmentCardType.Monopoly]: "Take all of one resource type from every player.",
-  [DevelopmentCardType.VictoryPoint]: "+1 Victory Point applied immediately!",
-};
+import { GamePhase, TurnPhase, DevelopmentCardType, DEV_CARD_NAMES, DEV_CARD_ICONS, DEV_CARD_DESC } from "@/engine/types";
 
 function DevCardRevealModal({ card, onClose }: { card: DevelopmentCardType; onClose: () => void }) {
   const isVP = card === DevelopmentCardType.VictoryPoint;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,62 @@ import GameLog from "@/components/ui/GameLog";
 import Scoreboard from "@/components/ui/Scoreboard";
 import DiscardDialog from "@/components/ui/DiscardDialog";
 import DiceDisplay from "@/components/ui/DiceDisplay";
-import { GamePhase, TurnPhase } from "@/engine/types";
+import { GamePhase, TurnPhase, DevelopmentCardType } from "@/engine/types";
+
+const DEV_CARD_NAMES: Record<DevelopmentCardType, string> = {
+  [DevelopmentCardType.Knight]: "Knight",
+  [DevelopmentCardType.RoadBuilding]: "Road Building",
+  [DevelopmentCardType.YearOfPlenty]: "Year of Plenty",
+  [DevelopmentCardType.Monopoly]: "Monopoly",
+  [DevelopmentCardType.VictoryPoint]: "Victory Point",
+};
+
+const DEV_CARD_ICONS: Record<DevelopmentCardType, string> = {
+  [DevelopmentCardType.Knight]: "🗡️",
+  [DevelopmentCardType.RoadBuilding]: "🛤️",
+  [DevelopmentCardType.YearOfPlenty]: "🎁",
+  [DevelopmentCardType.Monopoly]: "💰",
+  [DevelopmentCardType.VictoryPoint]: "⭐",
+};
+
+const DEV_CARD_DESC: Record<DevelopmentCardType, string> = {
+  [DevelopmentCardType.Knight]: "Move the robber and steal a resource from an adjacent player.",
+  [DevelopmentCardType.RoadBuilding]: "Place 2 roads for free.",
+  [DevelopmentCardType.YearOfPlenty]: "Take any 2 resources from the bank.",
+  [DevelopmentCardType.Monopoly]: "Take all of one resource type from every player.",
+  [DevelopmentCardType.VictoryPoint]: "+1 Victory Point applied immediately!",
+};
+
+function DevCardRevealModal({ card, onClose }: { card: DevelopmentCardType; onClose: () => void }) {
+  const isVP = card === DevelopmentCardType.VictoryPoint;
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
+      onClick={onClose}
+    >
+      <div
+        className="bg-gray-800 rounded-2xl p-8 shadow-2xl text-center max-w-xs mx-4 border border-purple-500 animate-slide-up"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="text-5xl mb-3">{DEV_CARD_ICONS[card]}</div>
+        <div className="text-xs uppercase tracking-widest text-purple-400 mb-1">Development Card Drawn</div>
+        <h3 className="text-2xl font-bold text-white mb-3">{DEV_CARD_NAMES[card]}</h3>
+        <p className={`text-sm mb-5 ${isVP ? "text-green-400" : "text-gray-400"}`}>
+          {DEV_CARD_DESC[card]}
+        </p>
+        {!isVP && (
+          <p className="text-xs text-gray-500 mb-5">Not playable until your next turn.</p>
+        )}
+        <button
+          className="bg-purple-700 hover:bg-purple-600 text-white px-6 py-2 rounded-lg font-medium transition-colors"
+          onClick={onClose}
+        >
+          Got it!
+        </button>
+      </div>
+    </div>
+  );
+}
 
 function ErrorToast({ message }: { message: string }) {
   const { setError } = useGameStore();
@@ -57,7 +112,7 @@ export default function Home() {
   useSocket();
   const { play: playSound, muted, toggleMute } = useSoundManager();
 
-  const { gameState, playerId, error, reconnecting } = useGameStore();
+  const { gameState, playerId, error, reconnecting, drawnDevCard, clearDrawnDevCard } = useGameStore();
 
   // Track previous state for triggering sounds
   const prevTurnPhaseRef = useRef<TurnPhase | null>(null);
@@ -155,6 +210,9 @@ export default function Home() {
     <div className="min-h-screen bg-gray-900 flex flex-col md:flex-row">
       {/* Toast error */}
       {error && <ErrorToast message={error} />}
+
+      {/* Dev card reveal modal */}
+      {drawnDevCard && <DevCardRevealModal card={drawnDevCard} onClose={clearDrawnDevCard} />}
 
       {/* Mute toggle */}
       <button

--- a/src/components/board/Harbor.tsx
+++ b/src/components/board/Harbor.tsx
@@ -10,7 +10,7 @@ import { HarborType } from "../../engine/types";
 const HARBOR_LABELS: Record<HarborType, { label: string; emoji: string }> = {
   [HarborType.Generic]: { label: "3:1", emoji: "⚓" },
   [HarborType.BrickHarbor]: { label: "2:1", emoji: "🧱" },
-  [HarborType.LumberHarbor]: { label: "2:1", emoji: "🪵" },
+  [HarborType.LumberHarbor]: { label: "2:1", emoji: "🌲" },
   [HarborType.WoolHarbor]: { label: "2:1", emoji: "🐑" },
   [HarborType.GrainHarbor]: { label: "2:1", emoji: "🌾" },
   [HarborType.OreHarbor]: { label: "2:1", emoji: "⛰️" },

--- a/src/components/ui/ActionPanel.tsx
+++ b/src/components/ui/ActionPanel.tsx
@@ -6,7 +6,7 @@
 
 import React, { useState, useCallback } from "react";
 import type { GameState } from "../../engine/types";
-import { GamePhase, TurnPhase, DevelopmentCardType, Resource, BUILDING_COSTS, hasResources } from "../../engine/types";
+import { GamePhase, TurnPhase, DevelopmentCardType, Resource, BUILDING_COSTS, hasResources, DEV_CARD_NAMES, DEV_CARD_ICONS } from "../../engine/types";
 import { useGameStore } from "../../stores/gameStore";
 import { useSocket } from "../../hooks/useSocket";
 import Tooltip from "./Tooltip";
@@ -314,8 +314,8 @@ export default function ActionPanel({ gameState }: ActionPanelProps) {
                   return acc;
                 }, {})
               ).map(([card, count]) => {
-                const emoji = { knight: "🗡️", roadBuilding: "🛤️", yearOfPlenty: "🎁", monopoly: "💰", victoryPoint: "⭐" }[card] ?? "🃏";
-                const name = { knight: "Knight", roadBuilding: "Road Building", yearOfPlenty: "Year of Plenty", monopoly: "Monopoly", victoryPoint: "Victory Point" }[card] ?? card;
+                const emoji = DEV_CARD_ICONS[card as DevelopmentCardType] ?? "🃏";
+                const name = DEV_CARD_NAMES[card as DevelopmentCardType] ?? card;
                 return (
                   <button
                     key={card}

--- a/src/components/ui/ActionPanel.tsx
+++ b/src/components/ui/ActionPanel.tsx
@@ -111,7 +111,7 @@ export default function ActionPanel({ gameState }: ActionPanelProps) {
   const canAffordSettlement = hasResources(myPlayer.resources, BUILDING_COSTS.settlement);
   const canAffordCity = hasResources(myPlayer.resources, BUILDING_COSTS.city);
   const canAffordDevCard = hasResources(myPlayer.resources, BUILDING_COSTS.developmentCard);
-  const canPlayDevCards = (canBuild || canRoll) && myPlayer.developmentCards.length > 0 && !myPlayer.hasPlayedDevCardThisTurn;
+  const canPlayDevCards = (canBuild || canRoll) && myPlayer.developmentCards.some(c => c !== DevelopmentCardType.VictoryPoint) && !myPlayer.hasPlayedDevCardThisTurn;
 
   return (
     <div className="bg-gray-800 rounded-lg p-4 space-y-3">

--- a/src/components/ui/ActionPanel.tsx
+++ b/src/components/ui/ActionPanel.tsx
@@ -181,7 +181,7 @@ export default function ActionPanel({ gameState }: ActionPanelProps) {
         {/* Build buttons */}
         {canBuild && (
           <>
-            <Tooltip content={!canAffordRoad ? "Need: 1🧱 1🪵" : "Road: 1🧱 1🪵"}>
+            <Tooltip content={!canAffordRoad ? "Need: 1🧱 1🌲" : "Road: 1🧱 1🌲"}>
               <button
                 className={`py-2 px-3 rounded font-medium text-sm transition-colors ${
                   !canAffordRoad
@@ -196,7 +196,7 @@ export default function ActionPanel({ gameState }: ActionPanelProps) {
                 🛤️ Road
               </button>
             </Tooltip>
-            <Tooltip content={!canAffordSettlement ? "Need: 1🧱 1🪵 1🐑 1🌾" : "Settlement: 1🧱 1🪵 1🐑 1🌾"}>
+            <Tooltip content={!canAffordSettlement ? "Need: 1🧱 1🌲 1🐑 1🌾" : "Settlement: 1🧱 1🌲 1🐑 1🌾"}>
               <button
                 className={`py-2 px-3 rounded font-medium text-sm transition-colors ${
                   !canAffordSettlement

--- a/src/components/ui/DiscardDialog.tsx
+++ b/src/components/ui/DiscardDialog.tsx
@@ -12,7 +12,7 @@ import { useSocket } from "../../hooks/useSocket";
 
 const RESOURCE_EMOJI: Record<Resource, string> = {
   [Resource.Brick]: "🧱",
-  [Resource.Lumber]: "🪵",
+  [Resource.Lumber]: "🌲",
   [Resource.Wool]: "🐑",
   [Resource.Grain]: "🌾",
   [Resource.Ore]: "⛰️",

--- a/src/components/ui/DiscardDialog.tsx
+++ b/src/components/ui/DiscardDialog.tsx
@@ -6,17 +6,9 @@
 
 import React, { useState } from "react";
 import type { GameState, ResourceHand } from "../../engine/types";
-import { Resource, totalResources } from "../../engine/types";
+import { Resource, totalResources, RESOURCE_EMOJI } from "../../engine/types";
 import { useGameStore } from "../../stores/gameStore";
 import { useSocket } from "../../hooks/useSocket";
-
-const RESOURCE_EMOJI: Record<Resource, string> = {
-  [Resource.Brick]: "🧱",
-  [Resource.Lumber]: "🌲",
-  [Resource.Wool]: "🐑",
-  [Resource.Grain]: "🌾",
-  [Resource.Ore]: "⛰️",
-};
 
 interface DiscardDialogProps {
   gameState: GameState;

--- a/src/components/ui/Lobby.tsx
+++ b/src/components/ui/Lobby.tsx
@@ -4,12 +4,12 @@
 
 "use client";
 
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import { useGameStore } from "../../stores/gameStore";
 import { useSocket } from "../../hooks/useSocket";
 import { PLAYER_COLORS } from "../../engine/types";
 
-function CopyButton({ text }: { text: string }) {
+function CopyButton({ text, title, label }: { text: string; title?: string; label?: string }) {
   const [copied, setCopied] = useState(false);
   const handleCopy = useCallback(() => {
     navigator.clipboard.writeText(text).then(() => {
@@ -21,9 +21,9 @@ function CopyButton({ text }: { text: string }) {
     <button
       onClick={handleCopy}
       className="bg-gray-600 hover:bg-gray-500 text-white rounded px-2 py-1 text-sm transition-colors"
-      title="Copy room code"
+      title={title ?? "Copy"}
     >
-      {copied ? "✓" : "📋"}
+      {copied ? "✓ Copied!" : (label ?? "📋")}
     </button>
   );
 }
@@ -33,6 +33,16 @@ export default function Lobby() {
   const { createRoom, joinRoom, leaveRoom, setReady, startGame } = useSocket();
   const [roomCode, setRoomCode] = useState("");
   const [maxPlayers, setMaxPlayers] = useState(4);
+
+  // Pre-fill room code from invite link (?join=CODE)
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const joinCode = params.get("join");
+    if (joinCode) {
+      setRoomCode(joinCode.toUpperCase());
+      history.replaceState(null, "", window.location.pathname);
+    }
+  }, []);
 
   // Not in a room — show create/join
   if (!room) {
@@ -131,7 +141,12 @@ export default function Lobby() {
           <span className="bg-gray-700 text-yellow-400 font-mono text-2xl tracking-[0.3em] px-4 py-1 rounded">
             {room.code}
           </span>
-          <CopyButton text={room.code} />
+          <CopyButton text={room.code} title="Copy room code" />
+          <CopyButton
+            text={`${window.location.origin}${window.location.pathname}?join=${room.code}`}
+            title="Copy invite link"
+            label="🔗 Invite"
+          />
         </div>
 
         {error && (

--- a/src/components/ui/Lobby.tsx
+++ b/src/components/ui/Lobby.tsx
@@ -39,6 +39,7 @@ export default function Lobby() {
     const params = new URLSearchParams(window.location.search);
     const joinCode = params.get("join");
     if (joinCode) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional one-time URL param read
       setRoomCode(joinCode.toUpperCase());
       history.replaceState(null, "", window.location.pathname);
     }

--- a/src/components/ui/PlayerHud.tsx
+++ b/src/components/ui/PlayerHud.tsx
@@ -106,7 +106,7 @@ export default function PlayerHud({ player, isCurrentPlayer, gameState }: Player
       </div>
 
       {/* Development Cards */}
-      {player.developmentCards.length > 0 && (
+      {(player.developmentCards.length > 0 || player.newDevCards.length > 0) && (
         <div className="mb-2">
           <div className="text-xs text-gray-400 mb-1">Development Cards:</div>
           <div className="flex flex-wrap gap-1">
@@ -116,6 +116,15 @@ export default function PlayerHud({ player, isCurrentPlayer, gameState }: Player
                 className="text-xs bg-purple-900 text-white px-1.5 py-0.5 rounded"
               >
                 {DEV_CARD_NAMES[card]}
+              </span>
+            ))}
+            {player.newDevCards.map((card, i) => (
+              <span
+                key={`new-${i}`}
+                className="text-xs bg-purple-900/50 text-purple-300 px-1.5 py-0.5 rounded border border-purple-600"
+                title="Drawn this turn — playable next turn"
+              >
+                {DEV_CARD_NAMES[card]} <span className="text-purple-400 text-[10px]">(new)</span>
               </span>
             ))}
           </div>

--- a/src/components/ui/PlayerHud.tsx
+++ b/src/components/ui/PlayerHud.tsx
@@ -6,16 +6,8 @@
 
 import React, { useState, useMemo } from "react";
 import type { PlayerState, GameState } from "../../engine/types";
-import { Resource, DevelopmentCardType, BUILDING_COSTS, BuildingType } from "../../engine/types";
+import { Resource, BUILDING_COSTS, BuildingType, RESOURCE_EMOJI, DEV_CARD_NAMES, DEV_CARD_ICONS } from "../../engine/types";
 import Tooltip from "./Tooltip";
-
-const RESOURCE_EMOJI: Record<Resource, string> = {
-  [Resource.Brick]: "🧱",
-  [Resource.Lumber]: "🌲",
-  [Resource.Wool]: "🐑",
-  [Resource.Grain]: "🌾",
-  [Resource.Ore]: "⛰️",
-};
 
 const RESOURCE_COLORS: Record<Resource, string> = {
   [Resource.Brick]: "bg-red-700",
@@ -23,14 +15,6 @@ const RESOURCE_COLORS: Record<Resource, string> = {
   [Resource.Wool]: "bg-green-200",
   [Resource.Grain]: "bg-yellow-500",
   [Resource.Ore]: "bg-gray-500",
-};
-
-const DEV_CARD_NAMES: Record<DevelopmentCardType, string> = {
-  [DevelopmentCardType.Knight]: "🗡️ Knight",
-  [DevelopmentCardType.RoadBuilding]: "🛤️ Road Building",
-  [DevelopmentCardType.YearOfPlenty]: "🎁 Year of Plenty",
-  [DevelopmentCardType.Monopoly]: "💰 Monopoly",
-  [DevelopmentCardType.VictoryPoint]: "⭐ Victory Point",
 };
 
 const COST_DISPLAY_NAMES: Record<string, string> = {
@@ -115,7 +99,7 @@ export default function PlayerHud({ player, isCurrentPlayer, gameState }: Player
                 key={i}
                 className="text-xs bg-purple-900 text-white px-1.5 py-0.5 rounded"
               >
-                {DEV_CARD_NAMES[card]}
+                {DEV_CARD_ICONS[card]} {DEV_CARD_NAMES[card]}
               </span>
             ))}
             {player.newDevCards.map((card, i) => (
@@ -124,7 +108,7 @@ export default function PlayerHud({ player, isCurrentPlayer, gameState }: Player
                 className="text-xs bg-purple-900/50 text-purple-300 px-1.5 py-0.5 rounded border border-purple-600"
                 title="Drawn this turn — playable next turn"
               >
-                {DEV_CARD_NAMES[card]} <span className="text-purple-400 text-[10px]">(new)</span>
+                {DEV_CARD_ICONS[card]} {DEV_CARD_NAMES[card]} <span className="text-purple-400 text-[10px]">(new)</span>
               </span>
             ))}
           </div>

--- a/src/components/ui/PlayerHud.tsx
+++ b/src/components/ui/PlayerHud.tsx
@@ -6,7 +6,7 @@
 
 import React, { useState, useMemo } from "react";
 import type { PlayerState, GameState } from "../../engine/types";
-import { Resource, BUILDING_COSTS, BuildingType, RESOURCE_EMOJI, DEV_CARD_NAMES, DEV_CARD_ICONS } from "../../engine/types";
+import { Resource, DevelopmentCardType, BUILDING_COSTS, BuildingType, RESOURCE_EMOJI, DEV_CARD_NAMES, DEV_CARD_ICONS } from "../../engine/types";
 import Tooltip from "./Tooltip";
 
 const RESOURCE_COLORS: Record<Resource, string> = {
@@ -106,7 +106,9 @@ export default function PlayerHud({ player, isCurrentPlayer, gameState }: Player
               <span
                 key={`new-${i}`}
                 className="text-xs bg-purple-900/50 text-purple-300 px-1.5 py-0.5 rounded border border-purple-600"
-                title="Drawn this turn — playable next turn"
+                title={card === DevelopmentCardType.VictoryPoint
+                  ? "VP cards count immediately — revealed at game end"
+                  : "Drawn this turn — playable next turn"}
               >
                 {DEV_CARD_ICONS[card]} {DEV_CARD_NAMES[card]} <span className="text-purple-400 text-[10px]">(new)</span>
               </span>

--- a/src/components/ui/PlayerHud.tsx
+++ b/src/components/ui/PlayerHud.tsx
@@ -11,7 +11,7 @@ import Tooltip from "./Tooltip";
 
 const RESOURCE_EMOJI: Record<Resource, string> = {
   [Resource.Brick]: "🧱",
-  [Resource.Lumber]: "🪵",
+  [Resource.Lumber]: "🌲",
   [Resource.Wool]: "🐑",
   [Resource.Grain]: "🌾",
   [Resource.Ore]: "⛰️",

--- a/src/components/ui/ResourcePickerModal.tsx
+++ b/src/components/ui/ResourcePickerModal.tsx
@@ -5,15 +5,7 @@
 "use client";
 
 import React, { useState, useCallback } from "react";
-import { Resource } from "../../engine/types";
-
-const RESOURCE_EMOJI: Record<Resource, string> = {
-  [Resource.Lumber]: "🌲",
-  [Resource.Brick]: "🧱",
-  [Resource.Wool]: "🐑",
-  [Resource.Grain]: "🌾",
-  [Resource.Ore]: "⛰️",
-};
+import { Resource, RESOURCE_EMOJI } from "../../engine/types";
 
 const RESOURCE_LABELS: Record<Resource, string> = {
   [Resource.Lumber]: "Lumber",

--- a/src/components/ui/ResourcePickerModal.tsx
+++ b/src/components/ui/ResourcePickerModal.tsx
@@ -8,7 +8,7 @@ import React, { useState, useCallback } from "react";
 import { Resource } from "../../engine/types";
 
 const RESOURCE_EMOJI: Record<Resource, string> = {
-  [Resource.Lumber]: "🪵",
+  [Resource.Lumber]: "🌲",
   [Resource.Brick]: "🧱",
   [Resource.Wool]: "🐑",
   [Resource.Grain]: "🌾",

--- a/src/components/ui/TradeModal.tsx
+++ b/src/components/ui/TradeModal.tsx
@@ -13,7 +13,7 @@ import { useSocket } from "../../hooks/useSocket";
 
 const RESOURCE_EMOJI: Record<Resource, string> = {
   [Resource.Brick]: "🧱",
-  [Resource.Lumber]: "🪵",
+  [Resource.Lumber]: "🌲",
   [Resource.Wool]: "🐑",
   [Resource.Grain]: "🌾",
   [Resource.Ore]: "⛰️",

--- a/src/components/ui/TradeModal.tsx
+++ b/src/components/ui/TradeModal.tsx
@@ -6,18 +6,10 @@
 
 import React, { useState, useRef } from "react";
 import type { GameState, ResourceHand } from "../../engine/types";
-import { Resource, TurnPhase } from "../../engine/types";
+import { Resource, TurnPhase, RESOURCE_EMOJI } from "../../engine/types";
 import { getMaritimeTradeRate } from "../../engine/resources";
 import { useGameStore } from "../../stores/gameStore";
 import { useSocket } from "../../hooks/useSocket";
-
-const RESOURCE_EMOJI: Record<Resource, string> = {
-  [Resource.Brick]: "🧱",
-  [Resource.Lumber]: "🌲",
-  [Resource.Wool]: "🐑",
-  [Resource.Grain]: "🌾",
-  [Resource.Ore]: "⛰️",
-};
 
 interface TradeModalProps {
   gameState: GameState;

--- a/src/engine/state.ts
+++ b/src/engine/state.ts
@@ -107,10 +107,10 @@ function log(state: GameState, message: string, playerId?: string): void {
 
 const RESOURCE_EMOJI: Record<Resource, string> = {
   [Resource.Brick]: "🧱",
-  [Resource.Lumber]: "🪵",
+  [Resource.Lumber]: "🌲",
   [Resource.Wool]: "🐑",
   [Resource.Grain]: "🌾",
-  [Resource.Ore]: "🪨",
+  [Resource.Ore]: "⛰️",
 };
 
 function formatResourceGains(gains: Partial<Record<Resource, number>>): string {

--- a/src/engine/state.ts
+++ b/src/engine/state.ts
@@ -16,6 +16,7 @@ import {
   BUILDING_COSTS,
   PIECE_LIMITS,
   PLAYER_COLORS,
+  RESOURCE_EMOJI,
   emptyResourceHand,
   hasResources,
 } from "./types";
@@ -104,14 +105,6 @@ export function createGame(
 function log(state: GameState, message: string, playerId?: string): void {
   state.log.push({ timestamp: Date.now(), message, playerId });
 }
-
-const RESOURCE_EMOJI: Record<Resource, string> = {
-  [Resource.Brick]: "🧱",
-  [Resource.Lumber]: "🌲",
-  [Resource.Wool]: "🐑",
-  [Resource.Grain]: "🌾",
-  [Resource.Ore]: "⛰️",
-};
 
 function formatResourceGains(gains: Partial<Record<Resource, number>>): string {
   return Object.entries(gains)

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -34,6 +34,38 @@ export enum DevelopmentCardType {
   VictoryPoint = "victoryPoint",
 }
 
+export const RESOURCE_EMOJI: Record<Resource, string> = {
+  [Resource.Brick]: "🧱",
+  [Resource.Lumber]: "🌲",
+  [Resource.Wool]: "🐑",
+  [Resource.Grain]: "🌾",
+  [Resource.Ore]: "⛰️",
+};
+
+export const DEV_CARD_NAMES: Record<DevelopmentCardType, string> = {
+  [DevelopmentCardType.Knight]: "Knight",
+  [DevelopmentCardType.RoadBuilding]: "Road Building",
+  [DevelopmentCardType.YearOfPlenty]: "Year of Plenty",
+  [DevelopmentCardType.Monopoly]: "Monopoly",
+  [DevelopmentCardType.VictoryPoint]: "Victory Point",
+};
+
+export const DEV_CARD_ICONS: Record<DevelopmentCardType, string> = {
+  [DevelopmentCardType.Knight]: "🗡️",
+  [DevelopmentCardType.RoadBuilding]: "🛤️",
+  [DevelopmentCardType.YearOfPlenty]: "🎁",
+  [DevelopmentCardType.Monopoly]: "💰",
+  [DevelopmentCardType.VictoryPoint]: "⭐",
+};
+
+export const DEV_CARD_DESC: Record<DevelopmentCardType, string> = {
+  [DevelopmentCardType.Knight]: "Move the robber and steal a resource from an adjacent player.",
+  [DevelopmentCardType.RoadBuilding]: "Place 2 roads for free.",
+  [DevelopmentCardType.YearOfPlenty]: "Take any 2 resources from the bank.",
+  [DevelopmentCardType.Monopoly]: "Take all of one resource type from every player.",
+  [DevelopmentCardType.VictoryPoint]: "+1 Victory Point applied immediately!",
+};
+
 export enum GamePhase {
   Lobby = "lobby",
   SetupForward = "setupForward",   // 1st round: player 1→N

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -4,6 +4,7 @@
 
 import { create } from "zustand";
 import type { GameState } from "../engine/types";
+import { DevelopmentCardType } from "../engine/types";
 
 export interface ChatMessage {
   playerId: string;
@@ -62,6 +63,10 @@ interface GameStore {
   setPendingRobberAction: (action: "knight" | "robber" | null) => void;
   clearRobberState: () => void;
 
+  // Dev card reveal
+  drawnDevCard: DevelopmentCardType | null;
+  clearDrawnDevCard: () => void;
+
   // Error
   error: string | null;
   setError: (error: string | null) => void;
@@ -91,9 +96,20 @@ export const useGameStore = create<GameStore>((set) => ({
       const turnChanged =
         prev.gameState &&
         prev.gameState.currentPlayerIndex !== gameState.currentPlayerIndex;
+
+      // Detect a newly drawn dev card for this player
+      let drawnDevCard = prev.drawnDevCard;
+      if (prev.gameState && prev.playerId) {
+        const prevPlayer = prev.gameState.players.find((p) => p.id === prev.playerId);
+        const newPlayer = gameState.players.find((p) => p.id === prev.playerId);
+        if (prevPlayer && newPlayer && newPlayer.newDevCards.length > prevPlayer.newDevCards.length) {
+          drawnDevCard = newPlayer.newDevCards[newPlayer.newDevCards.length - 1];
+        }
+      }
+
       return turnChanged
-        ? { gameState, selectedAction: null, roadBuildingEdges: [], pendingKnight: false, pendingRobberHex: null, pendingStealTargets: [], pendingRobberAction: null }
-        : { gameState };
+        ? { gameState, drawnDevCard, selectedAction: null, roadBuildingEdges: [], pendingKnight: false, pendingRobberHex: null, pendingStealTargets: [], pendingRobberAction: null }
+        : { gameState, drawnDevCard };
     }),
 
   chatMessages: [],
@@ -122,6 +138,9 @@ export const useGameStore = create<GameStore>((set) => ({
     pendingRobberAction: null,
   }),
 
+  drawnDevCard: null,
+  clearDrawnDevCard: () => set({ drawnDevCard: null }),
+
   error: null,
   setError: (error) => set({ error }),
 
@@ -141,6 +160,7 @@ export const useGameStore = create<GameStore>((set) => ({
       pendingRobberHex: null,
       pendingStealTargets: [],
       pendingRobberAction: null,
+      drawnDevCard: null,
       error: null,
       playerId: null,
       reconnecting: false,

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -97,7 +97,9 @@ export const useGameStore = create<GameStore>((set) => ({
         prev.gameState &&
         prev.gameState.currentPlayerIndex !== gameState.currentPlayerIndex;
 
-      // Detect a newly drawn dev card for this player
+      // Detect a newly drawn dev card for this player by comparing newDevCards
+      // array length across state updates. Safe because newDevCards is sanitized
+      // to [] for opponents, so this only fires for the local player's purchases.
       let drawnDevCard = prev.drawnDevCard;
       if (prev.gameState && prev.playerId) {
         const prevPlayer = prev.gameState.players.find((p) => p.id === prev.playerId);


### PR DESCRIPTION
 1. Resource emoji compatibility fix (7 files)
  Replaced Unicode 13.0 emoji that show as empty boxes on older devices:
  - 🪵 (lumber) → 🌲 — affects state.ts, PlayerHud, TradeModal, ResourcePickerModal, DiscardDialog, Harbor, ActionPanel
  - 🪨 (ore) → ⛰️ — only needed in state.ts (other files already used ⛰️)

  2. Invite link (Lobby.tsx)
  - Added a "🔗 Invite" button in the waiting room that copies https://yoursite.com/?join=ROOMCODE to clipboard
  - On page load, reads ?join= from the URL, pre-fills the room code input, and strips the param from history so refresh doesn't re-trigger it

  3. Dev card reveal on purchase (3 files)
  - gameStore.ts: Added drawnDevCard state; setGameState now detects when a new card appears in the player's newDevCards and records it
  - PlayerHud.tsx: Shows newDevCards immediately with a dimmed "(new)" badge and tooltip explaining they're not playable until next turn
  - page.tsx: Added DevCardRevealModal — a centered overlay showing the card's icon, name, description, and a note about VP cards applying immediately vs. others
  waiting until next turn